### PR TITLE
Refactor selectors based on deprecation warnings

### DIFF
--- a/stylesheets/base.less
+++ b/stylesheets/base.less
@@ -1,54 +1,55 @@
 @import "syntax-variables";
 
-.editor {
+atom-text-editor {
   background-color: @syntax-background-color;
   color: @syntax-text-color;
 }
 
-.editor .gutter {
+atom-text-editor .gutter {
   background-color: @syntax-gutter-background-color;
   color: @syntax-gutter-text-color;
 }
 
-.editor .gutter .line-number.cursor-line {
+atom-text-editor .gutter .line-number.cursor-line {
   background-color: @syntax-gutter-background-color-selected;
   color: @syntax-gutter-text-color-selected;
 }
 
-.editor .gutter .line-number.cursor-line-no-selection {
+atom-text-editor .gutter .line-number.cursor-line-no-selection {
   color: @syntax-gutter-text-color-selected;
 }
 
-.editor .wrap-guide {
+atom-text-editor .wrap-guide {
   color: @syntax-wrap-guide-color;
 }
 
-.editor .indent-guide {
+atom-text-editor .indent-guide {
   color: @syntax-indent-guide-color;
 }
 
-.editor .invisible-character {
+atom-text-editor .invisible-character {
   color: @syntax-invisible-character-color;
 }
 
-.editor .search-results .marker .region {
+atom-text-editor .search-results .marker .region {
   background-color: transparent;
   border: @syntax-result-marker-color;
 }
 
-.editor .search-results .marker.current-result .region {
+atom-text-editor .search-results .marker.current-result .region {
   border: @syntax-result-marker-color-selected;
 }
 
-.editor.is-focused .cursor {
+atom-text-editor.is-focused .cursor {
   border-color: @syntax-cursor-color;
 }
 
-.editor.is-focused .selection .region {
+atom-text-editor.is-focused .selection .region {
   background-color: @syntax-selection-color;
 }
 
-.editor.is-focused .line-number.cursor-line-no-selection, .editor.is-focused .line.cursor-line {
+atom-text-editor.is-focused .line-number.cursor-line-no-selection,
+atom-text-editor.is-focused .line.cursor-line {
   background-color: #1a2631;
 }
 
@@ -57,7 +58,12 @@
   color: #407c9b;
 }
 
-.keyword, .punctuation.section.embedded.begin.php, .punctuation.section.embedded.end.php, .meta.tag.sgml.html, .keyword.operator.logical.php, .keyword.operator.logical.ruby {
+.keyword,
+.punctuation.section.embedded.begin.php,
+.punctuation.section.embedded.end.php,
+.meta.tag.sgml.html,
+.keyword.operator.logical.php,
+.keyword.operator.logical.ruby {
   color: #e67055;
 }
 
@@ -113,7 +119,9 @@
   color: #bd85e3;
 }
 
-.string.regexp .constant.character.escape, .string.regexp .source.ruby.embedded, .string.regexp .string.regexp.arbitrary-repitition {
+.string.regexp .constant.character.escape,
+.string.regexp .source.ruby.embedded,
+.string.regexp .string.regexp.arbitrary-repitition {
   color: #be73fd;
 }
 
@@ -137,15 +145,25 @@
   color: #34d58e;
 }
 
-.meta.tag.sgml.doctype, .meta.tag.sgml.doctype .entity, .meta.tag.sgml.doctype .string, .meta.tag.preprocessor.xml, .meta.tag.preprocessor.xml .entity, .meta.tag.preprocessor.xml .string {
+.meta.tag.sgml.doctype,
+.meta.tag.sgml.doctype .entity,
+.meta.tag.sgml.doctype .string,
+.meta.tag.preprocessor.xml,
+.meta.tag.preprocessor.xml .entity,
+.meta.tag.preprocessor.xml .string {
   color: #e67055;
 }
 
-.declaration.tag, .declaration.tag .entity, .meta.tag, .meta.tag .entity {
+.declaration.tag,
+.declaration.tag .entity,
+.meta.tag,
+.meta.tag .entity {
   color: #e39f32;
 }
 
-.meta.diff, .meta.diff.header, .meta.separator {
+.meta.diff,
+.meta.diff.header,
+.meta.separator {
   font-style: italic;
   color: #F8F8F8;
   background-color: #0E2231;
@@ -174,7 +192,10 @@
   color: #9d78e3;
 }
 
-.keyword.control.untitled, .entity.other.attribute-name.class.sass, .entity.other.attribute-name.id.sass, .entity.other.attribute-name.tag.pseudo-class {
+.keyword.control.untitled,
+.entity.other.attribute-name.class.sass,
+.entity.other.attribute-name.id.sass,
+.entity.other.attribute-name.tag.pseudo-class {
   color: #34d58e;
 }
 
@@ -186,19 +207,30 @@
   color: #e67055;
 }
 
-.support.function.misc, .punctuation.section.function.css, .string.quoted.single.css, .string.quoted.double.css, .string.quoted.single.html, .string.quoted.double.html {
+.support.function.misc,
+.punctuation.section.function.css,
+.string.quoted.single.css,
+.string.quoted.double.css,
+.string.quoted.single.html,
+.string.quoted.double.html {
   color: #ecdd5d;
 }
 
-.entity.name.tag.css, .support.type.property-name.css, .meta.property-name.css {
+.entity.name.tag.css,
+.support.type.property-name.css,
+.meta.property-name.css {
   color: #4dccbc;
 }
 
-.meta.property-group .support.constant.property-value.css, .meta.property-value .support.constant.property-value.css, .meta.property-value.css {
+.meta.property-group .support.constant.property-value.css,
+.meta.property-value .support.constant.property-value.css,
+.meta.property-value.css {
   color: #e67055;
 }
 
-.meta.property-value .support.constant.named-color.css, .meta.property-value .constant, .keyword.other.unit.css {
+.meta.property-value .support.constant.named-color.css,
+.meta.property-value .constant,
+.keyword.other.unit.css {
   color: #9d78e3;
 }
 
@@ -210,6 +242,18 @@
   color: #16a085;
 }
 
-.meta.selector.css, .entity.name.tag.css, .meta.selector.css, .entity.other.attribute-name.class, .meta.selector.css, .entity.other.attribute-name.id, .entity.other.attribute-name.pseudo-element.css, .entity.other.attribute-name.pseudo-class.css, .source.css, .meta.selector.css, .entity.other.attribute-name.pseudo-class.css, .punctuation.separator.key-value, .punctuation.terminator.rule.css {
+.meta.selector.css,
+.entity.name.tag.css,
+.meta.selector.css,
+.entity.other.attribute-name.class,
+.meta.selector.css,
+.entity.other.attribute-name.id,
+.entity.other.attribute-name.pseudo-element.css,
+.entity.other.attribute-name.pseudo-class.css,
+.source.css,
+.meta.selector.css,
+.entity.other.attribute-name.pseudo-class.css,
+.punctuation.separator.key-value,
+.punctuation.terminator.rule.css {
   color: #34d58e;
 }

--- a/stylesheets/base.less
+++ b/stylesheets/base.less
@@ -1,56 +1,67 @@
 @import "syntax-variables";
 
-atom-text-editor {
+atom-text-editor, :host {
   background-color: @syntax-background-color;
   color: @syntax-text-color;
-}
 
-atom-text-editor .gutter {
-  background-color: @syntax-gutter-background-color;
-  color: @syntax-gutter-text-color;
-}
+  .gutter {
+    background-color: @syntax-gutter-background-color;
+    color: @syntax-gutter-text-color;
 
-atom-text-editor .gutter .line-number.cursor-line {
-  background-color: @syntax-gutter-background-color-selected;
-  color: @syntax-gutter-text-color-selected;
-}
+    .line-number {
 
-atom-text-editor .gutter .line-number.cursor-line-no-selection {
-  color: @syntax-gutter-text-color-selected;
-}
+      &.cursor-line {
+        background-color: @syntax-gutter-background-color-selected;
+        color: @syntax-gutter-text-color-selected;
+      }
 
-atom-text-editor .wrap-guide {
-  color: @syntax-wrap-guide-color;
-}
+      &.cursor-line-no-selection {
+        color: @syntax-gutter-text-color-selected;
+      }
 
-atom-text-editor .indent-guide {
-  color: @syntax-indent-guide-color;
-}
+    }
 
-atom-text-editor .invisible-character {
-  color: @syntax-invisible-character-color;
-}
+  }
 
-atom-text-editor .search-results .marker .region {
-  background-color: transparent;
-  border: @syntax-result-marker-color;
-}
+  .indent-guide {
+    color: @syntax-indent-guide-color;
+  }
 
-atom-text-editor .search-results .marker.current-result .region {
-  border: @syntax-result-marker-color-selected;
-}
+  .invisible-character {
+    color: @syntax-invisible-character-color;
+  }
 
-atom-text-editor.is-focused .cursor {
-  border-color: @syntax-cursor-color;
-}
+  .search-results {
+    .marker {
+      .region {
+        background-color: transparent;
+        border: @syntax-result-marker-color;
+      }
+      &.current-result .region {
+        border: @syntax-result-marker-color-selected;
+      }
+    }
+  }
 
-atom-text-editor.is-focused .selection .region {
-  background-color: @syntax-selection-color;
-}
+  .wrap-guide {
+    color: @syntax-wrap-guide-color;
+  }
 
-atom-text-editor.is-focused .line-number.cursor-line-no-selection,
-atom-text-editor.is-focused .line.cursor-line {
-  background-color: #1a2631;
+  &.is-focused {
+    .cursor {
+      border-color: @syntax-cursor-color;
+    }
+
+    .line.cursor-line,
+    .line-number.cursor-line-no-selection {
+      background-color: #1a2631;
+    }
+
+    .selection .region {
+      background-color: @syntax-selection-color;
+    }
+  }
+
 }
 
 .comment {


### PR DESCRIPTION
Here's my attempt at migrating the editor theme over to the new shadow-DOM syntax [outlined here](https://atom.io/docs/latest/upgrading/upgrading-your-ui-theme)